### PR TITLE
fix typo that broke links - en Malware

### DIFF
--- a/_pages/en/Malware.md
+++ b/_pages/en/Malware.md
@@ -5,7 +5,7 @@ author: RaReNet
 language: en
 summary: "*Malware* is malicious software that facilitates an unauthorized takeover of your device by another user, government or third party to perform surveillance functions such as recording keystrokes, stealing passwords, taking screenshots, recording audio, video and more. While most malware is designed for and utilized by criminals, state-sponsored actors have increasingly adopted malware as a tool for surveillance, espionage and sabotage. Malware is used to gain control of devices."
 date: 2015-08
-permalink: /en/malware/
+permalink: /en/Malware/
 parent: /en/
 ---
 


### PR DESCRIPTION
current links to Malware section break: https://rarenet.github.io/DFAK/en/